### PR TITLE
fix: access to image url

### DIFF
--- a/server/config/filesystems.php
+++ b/server/config/filesystems.php
@@ -43,7 +43,11 @@ return [
             'visibility' => 'public',
             'throw' => false,
         ],
-
+        'media' => [
+            'driver' => 'local',
+            'root'   => public_path('media'),
+            'url'    => env('APP_URL').'/media',
+        ],
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/server/config/media-library.php
+++ b/server/config/media-library.php
@@ -6,7 +6,7 @@ return [
      * The disk on which to store added files and derived images by default. Choose
      * one or more of the disks you've configured in config/filesystems.php.
      */
-    'disk_name' => env('MEDIA_DISK', 'public'),
+    'disk_name' => env('MEDIA_DISK', 'media'),
 
     /*
      * The maximum file size of an item in bytes.


### PR DESCRIPTION
Filesystem "media" added.

The "storage" folder is not accessible via HTTP requests; it is private. Spatie recommends using the "media" for management.

Source: https://spatie.be/docs/laravel-medialibrary/v10/installation-setup#content-adding-a-media-disk

